### PR TITLE
Change the temporary album_art dir to default to XDG_RUNTIME_DIR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,6 +653,7 @@ dependencies = [
  "async-std",
  "clap",
  "colored 2.0.0",
+ "dirs",
  "fern",
  "log",
  "nom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ signal-hook = "0.3"
 signal-hook-async-std = "0.2"
 # Config
 clap = { version = "4", features = ["derive"]}
+dirs = "4.0.0"
 
 [profile.release]
 lto = true

--- a/src/mpd/stateserver.rs
+++ b/src/mpd/stateserver.rs
@@ -223,8 +223,11 @@ pub async fn update_album_art(c: &mut MpdClient) -> Result<PathBuf> {
         Some(mut id) => id.remove(0),
         None => bail!("invalid MPD response: no current song ID"),
     };
+    let pic_dir = match dirs::runtime_dir() {
+        Some(path) => PathBuf::from(path),
+        None => PathBuf::from("/tmp"),
+    }.join("mpd/album_art/");
 
-    let pic_dir = PathBuf::from("/tmp/mpd/album_art/");
     if !pic_dir.is_dir().await {
         async_std::fs::create_dir_all(&pic_dir).await?;
     }


### PR DESCRIPTION
Making the album_art cache use $XDG_RUNTIME_DIR allows it to avoid any conflicts when running multiple instances at once.

Can still fall back to /tmp if the RUNTIME_DIR isn't available