### PR TITLE
Add support for Linux abstract sockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@ If using Linux with systemd, you can use systemd user service to run mpdris2-rs.
 This program reads the D-Bus session bus path from `$DBUS_SESSION_BUS_ADDRESS` and fall back to `$XDG_RUNTIME_DIR/bus` if such variable is not defined. Usually this variable should be set automatically when using desktop environments like KDE and GNOME, but if you are using a window manager or launching DE session by yourself, you might need to start your graphical session with `dbus-launch --exit-with-session $CMD`.
 
 Currently the following command line arguments are supported:
-- `--host $MPD_HOST` hostname + port, or UNIX socket path of MPD server, similar to what `mpc` takes
+- `--host $MPD_HOST` or `-h $MPD_HOST` hostname + port, or UNIX socket path of MPD server, similar to what `mpc` takes
   - if not configured, `MPD_HOST` will be used
   - if `MPD_HOST` is not set either, `localhost:6600` is the default
-  - UNIX socket path has to be absolute, and abstract sockets (socket path that starts with `@`) are not supported
+  - UNIX socket path has to be absolute
+  - Abstract sockets are supported on Linux (socket path that starts with `@`, e.g., `@mpd_socket`)
 - `--no-notification` don't send desktop notification
 - `-v` show debug information
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,9 +7,10 @@ use argh::FromArgs;
 pub struct Args {
     /// host address of MPD server
     /// default to `MPD_HOST` or `localhost:6600`
-    /// can be a TCP address + port (i.e. localhost:6600) or a socket path (i.e. /var/run/mpd/socket)
-    /// socket path must be an absolute path
-    #[argh(option)]
+    /// can be a TCP address + port (i.e. localhost:6600), a socket path (i.e. /var/run/mpd/socket),
+    /// or an abstract socket (i.e. @mpd_socket)
+    /// socket path must be an absolute path, abstract sockets start with @
+    #[argh(option, short = 'h')]
     pub host: Option<String>,
     /// disable notification
     #[argh(switch)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,11 +141,58 @@ fn setup_logger(debug: u8) -> Result<()> {
 }
 
 fn parse_host_string(s: String) -> MpdConnectionConfig {
-    if s.starts_with('/') {
+    if s.starts_with('@') {
+        // Abstract socket - @ prefix will be stripped when connecting
+        MpdConnectionConfig::AbstractSocket(s)
+    } else if s.starts_with('/') {
         // UNIX socket
         let path = PathBuf::from(s);
         MpdConnectionConfig::Socket(path)
     } else {
         MpdConnectionConfig::Tcp(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_host_string_tcp() {
+        assert!(matches!(
+            parse_host_string("localhost:6600".to_string()),
+            MpdConnectionConfig::Tcp(s) if s == "localhost:6600"
+        ));
+
+        assert!(matches!(
+            parse_host_string("192.168.1.1:6600".to_string()),
+            MpdConnectionConfig::Tcp(s) if s == "192.168.1.1:6600"
+        ));
+    }
+
+    #[test]
+    fn test_parse_host_string_socket() {
+        assert!(matches!(
+            parse_host_string("/var/run/mpd/socket".to_string()),
+            MpdConnectionConfig::Socket(path) if path == PathBuf::from("/var/run/mpd/socket")
+        ));
+
+        assert!(matches!(
+            parse_host_string("/tmp/mpd.sock".to_string()),
+            MpdConnectionConfig::Socket(path) if path == PathBuf::from("/tmp/mpd.sock")
+        ));
+    }
+
+    #[test]
+    fn test_parse_host_string_abstract_socket() {
+        assert!(matches!(
+            parse_host_string("@mpd_socket".to_string()),
+            MpdConnectionConfig::AbstractSocket(s) if s == "@mpd_socket"
+        ));
+
+        assert!(matches!(
+            parse_host_string("@/tmp/mpd".to_string()),
+            MpdConnectionConfig::AbstractSocket(s) if s == "@/tmp/mpd"
+        ));
     }
 }

--- a/src/mpd/client.rs
+++ b/src/mpd/client.rs
@@ -14,6 +14,7 @@ use tokio::{
 enum MpdConnection {
     Tcp((BufReader<tcp::OwnedReadHalf>, BufWriter<tcp::OwnedWriteHalf>)),
     Socket((BufReader<unix::OwnedReadHalf>, BufWriter<unix::OwnedWriteHalf>)),
+    AbstractSocket((BufReader<unix::OwnedReadHalf>, BufWriter<unix::OwnedWriteHalf>)),
 }
 
 impl MpdConnection {
@@ -36,6 +37,24 @@ impl MpdConnection {
                 let (r, w) = (BufReader::new(r), BufWriter::new(w));
                 MpdConnection::Socket((r, w))
             }
+            MpdConnectionConfig::AbstractSocket(abstract_name) => {
+                #[cfg(target_os = "linux")]
+                {
+                    // Replace @ with null byte for abstract socket
+                    let path = format!("\0{}", &abstract_name[1..]);
+                    let stream = UnixStream::connect(&path).await.context(format!(
+                        "Cannot connect to MPD server with abstract socket: {}",
+                        abstract_name.escape_default()
+                    ))?;
+                    let (r, w) = stream.into_split();
+                    let (r, w) = (BufReader::new(r), BufWriter::new(w));
+                    MpdConnection::AbstractSocket((r, w))
+                }
+                #[cfg(not(target_os = "linux"))]
+                {
+                    bail!("Abstract sockets are only supported on Linux");
+                }
+            }
         };
 
         Ok(res)
@@ -45,6 +64,7 @@ impl MpdConnection {
         match self {
             MpdConnection::Tcp((r, _)) => r.read_line(buf).await,
             MpdConnection::Socket((r, _)) => r.read_line(buf).await,
+            MpdConnection::AbstractSocket((r, _)) => r.read_line(buf).await,
         }
     }
 
@@ -52,6 +72,7 @@ impl MpdConnection {
         match self {
             MpdConnection::Tcp((r, _)) => r.read_exact(buf).await,
             MpdConnection::Socket((r, _)) => r.read_exact(buf).await,
+            MpdConnection::AbstractSocket((r, _)) => r.read_exact(buf).await,
         }
     }
 
@@ -63,6 +84,10 @@ impl MpdConnection {
                 w.flush().await?;
             }
             MpdConnection::Socket((_, w)) => {
+                w.write_all(src).await?;
+                w.flush().await?;
+            }
+            MpdConnection::AbstractSocket((_, w)) => {
                 w.write_all(src).await?;
                 w.flush().await?;
             }

--- a/src/types.rs
+++ b/src/types.rs
@@ -50,4 +50,5 @@ impl SongMetadata {
 pub enum MpdConnectionConfig {
     Tcp(String),
     Socket(PathBuf),
+    AbstractSocket(String),
 }


### PR DESCRIPTION
The program now accepts abstract socket paths (e.g. @mpd_socket) for MPD connections. This is a Linux-specific feature that provides an alternative to filesystem-based UNIX domain sockets.