### PR TITLE
fix(albumart): execute albumart command, not just readpicture

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,7 @@
+## [unreleased]
+
+- Fix viewing album art when it's in a separate file to the song.
+
 ## 1.0.0 - 2025-06-16
 
 - First release

--- a/src/mpd/albumart.rs
+++ b/src/mpd/albumart.rs
@@ -52,7 +52,7 @@ pub async fn update_album_art(
     // Not in cache, fetch it
     let mut new_pic_hash = None;
     for cmd in ["readpicture", "albumart"] {
-        match mpd_binary_to_file(c, "readpicture", uri, &path).await {
+        match mpd_binary_to_file(c, cmd, uri, &path).await {
             Ok(Some(pic_hash)) => {
                 new_pic_hash = Some(pic_hash);
                 break;


### PR DESCRIPTION
this fixes viewing album art when it's in a separate file to the song
