### PR TITLE
Update status on playlist change

### DIFF
--- a/src/mpd/stateserver.rs
+++ b/src/mpd/stateserver.rs
@@ -21,7 +21,7 @@ use tokio::{
     time::sleep,
 };
 
-const IDLE_CMD: &str = "idle player mixer options";
+const IDLE_CMD: &str = "idle player mixer playlist options";
 const PING_INTERVAL: Duration = Duration::from_secs(55);
 
 pub struct MpdStateServer {


### PR DESCRIPTION
I am using symfonium + upmpdcli. When evaluating a queue, synfonium only sends the next track for lookahead (I dont know if it is actually symfonium or umpdcli). After the initial tracklist is loaded, I cant go to the next track, the boolean is always false.

I am getting three playlist events every time a track ends or I go to the next one.

Example:
```
DEBUG [mpdris2_rs::mpd::stateserver] idle response: changed = player
DEBUG [mpdris2_rs::mpd::albumart] Creating new album art file at /run/user/1000/mpd/album_art/i896yr7yc66ec
DEBUG [mpdris2_rs::plugins::fdo_notification] Last notification timed out. Resetting internal register.
DEBUG [mpdris2_rs::plugins::fdo_notification] Last notification sent on 81.110776029s, we shouldn't be hitting rate limits
DEBUG [mpdris2_rs::mpd::stateserver] idle response: changed = playlist
DEBUG [mpdris2_rs::mpd::stateserver] idle response: changed = player
DEBUG [mpdris2_rs::plugins::fdo_notification] New notification id is 188
DEBUG [mpdris2_rs::plugins::fdo_notification] Last notification sent on 15.15µs, we shouldn't be hitting rate limits
DEBUG [mpdris2_rs::plugins::fdo_notification] Not sending notification due to rate-limit.
DEBUG [mpdris2_rs::mpd::albumart] Creating new album art file at /run/user/1000/mpd/album_art/3pjwa16b4u4dc
DEBUG [mpdris2_rs::plugins::fdo_notification] Last notification sent on 556.964867ms, we shouldn't be hitting rate limits
DEBUG [mpdris2_rs::plugins::fdo_notification] New notification id is 188
DEBUG [mpdris2_rs::mpd::stateserver] idle response: changed = playlist
DEBUG [mpdris2_rs::mpd::stateserver] idle response: changed = playlist
```
It seems that either the last or second to last one actually updates the playlist with the new track, so we are missing it because we are not recognizing the event. We basically have no next track whenever we update with can_go_next.

